### PR TITLE
Delete the link to the navigation drawer

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -67,13 +67,3 @@ function local_greetings_extend_navigation_frontpage(navigation_node $frontpage)
         navigation_node::TYPE_CUSTOM,
     );
 }
-
-function local_greetings_extend_navigation(global_navigation $root) {
-    $node = navigation_node::create(
-        get_string('pluginname', 'local_greetings'),
-        new moodle_url('/local/greetings/index.php')
-    );
-
-    $node->showinflatnavigation = true;
-    $root->add_node($node);
-}


### PR DESCRIPTION
The link to the navigation drawer was deleted because of this function require a specific Moodle theme.